### PR TITLE
chore: bump argus builder

### DIFF
--- a/.github/workflows/docker-build-prod.yaml
+++ b/.github/workflows/docker-build-prod.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   argus_builder:
-    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v4.1.0
+    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v4.2.0
     secrets: inherit
     with:
       envs: prod

--- a/.github/workflows/docker-build-rdev.yaml
+++ b/.github/workflows/docker-build-rdev.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   argus_builder:
-    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v4.0.0
+    uses: chanzuckerberg/github-actions/.github/workflows/argus-docker-build.yaml@v4.2.0
     secrets: inherit
     if: github.actor != 'dependabot[bot]'
     with:


### PR DESCRIPTION
https://czi.atlassian.net/browse/CCIE-4050

This upgrades to using v4.2.0 of the argus builder which has detection of whether a PR has the stack label built-in, ie rdev values.yaml will only be updated now when the stack label is on a PR

Additionally, and more importantly, this new version uses the newer self-hosted runners